### PR TITLE
Use `tini` with Kinesalite in order to handle SIGTERM

### DIFF
--- a/appliances/kinesalite/Dockerfile
+++ b/appliances/kinesalite/Dockerfile
@@ -13,4 +13,4 @@ VOLUME $DATADIR
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/entrypoint.sh", "--path", "/var/lib/kinesalite"]
+ENTRYPOINT ["/tini", "--", "/entrypoint.sh", "--path", "/var/lib/kinesalite"]


### PR DESCRIPTION
This fixes a problem when using the Kinesalite image in for instance Docker
Compose, where the SIGTERM signal doesn't have any effect on a container
running the image. Docker Compose first sends a SIGTERM signal to containers
when running `docker-compose down` and then waits by default 10 seconds
before proceeding to send a SIGKILL signal. As a result of the SIGTERM
signal not being handled it always takes at least 10 seconds to stop the
Kinesalite container.

This commit fixes that by running the entrypoint script with `tini`, which
takes care of passing the signals to the child processes correctly.