### PR TITLE
Updated to support latest version of kinesalite

### DIFF
--- a/appliances/kinesalite/Dockerfile
+++ b/appliances/kinesalite/Dockerfile
@@ -7,7 +7,7 @@ USER root
 RUN mkdir $DATADIR && chown docker:docker $DATADIR
 USER docker
 
-RUN npm install kinesalite@1.14.0
+RUN npm install kinesalite@3.3.1
 
 EXPOSE 4567
 VOLUME $DATADIR


### PR DESCRIPTION
This Kinesalite Dockerfile is used by Apache Flink during test case execution of the flink-connector-kinesis project. This version of kinesalite stopped working with the latest AWS SDK, and therefore it needed a bump. 

In the meantime I have tested that the flink test cases pass on the latest version of kinesalite (3.3.1) - it would be good if you could incorporate this change and get this version back onto docker hub.